### PR TITLE
feat(api): add posts search route and include total count in paginate…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next",
       "version": "0.1.0",
       "dependencies": {
-        "@prisma/client": "^6.11.1",
+        "@prisma/client": "^6.12.0",
         "@types/cookie": "^1.0.0",
         "bcrypt": "^6.0.0",
         "cookie": "^1.0.2",
@@ -993,10 +993,11 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.11.1.tgz",
-      "integrity": "sha512-5CLFh8QP6KxRm83pJ84jaVCeSVPQr8k0L2SEtOJHwdkS57/VQDcI/wQpGmdyOZi+D9gdNabdo8tj1Uk+w+upsQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.12.0.tgz",
+      "integrity": "sha512-wn98bJ3Cj6edlF4jjpgXwbnQIo/fQLqqQHPk2POrZPxTlhY3+n90SSIF3LMRVa8VzRFC/Gec3YKJRxRu+AIGVA==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
   "dependencies": {
-    "@prisma/client": "^6.11.1",
+    "@prisma/client": "^6.12.0",
     "@types/cookie": "^1.0.0",
     "bcrypt": "^6.0.0",
     "cookie": "^1.0.2",

--- a/src/app/api/posts/search/route.ts
+++ b/src/app/api/posts/search/route.ts
@@ -1,0 +1,41 @@
+import prisma from "@/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+
+
+/**
+ * @method GET
+ * @route ~/api/posts/search?searchQuery=value
+ * @description Search All Posts by search text
+ * @access Public
+ */
+export async function GET(request: NextRequest) {
+    try {
+        const searchQuery = request.nextUrl.searchParams.get("searchQuery");
+        let posts;
+
+        if (searchQuery) {
+            posts = await prisma.post.findMany({
+                where: {
+                    title: {
+                        contains: searchQuery,
+                    }
+                }
+            });
+
+            return NextResponse.json({
+                posts
+            }, { status: 200 })
+        } else {
+            posts = await prisma.post.findMany({ take: 6 })
+            return NextResponse.json({
+                posts
+            }, { status: 200 })
+        }
+
+    } catch (error) {
+        return NextResponse.json({
+            msg: "Internal Server Error",
+            error: (error as Error).message
+        }, { status: 500 })
+    }
+}


### PR DESCRIPTION
…d posts response.

- Added new API route `~/api/posts/search?searchQuery=value` to search posts by title using a query parameter (`searchQuery`).
- Updated `~/api/posts` GET endpoint to return both the list of posts and the total count for pagination.
- Optimized posts and count fetching using Promise.all for better performance.
- Upgraded `@prisma/client to v6.12.0` to support latest features.